### PR TITLE
Fix display of widget when there are no articles.

### DIFF
--- a/collapsed-archives.php
+++ b/collapsed-archives.php
@@ -105,8 +105,8 @@ function collapsed_archives_get_collapsed_archives( $args = '' ) {
             }
             $output .= get_archives_link( $url, $text, 'html', '', $after );
         }
+        $output .= '</ul></li></ul></div>';
     }
-    $output .= '</ul></li></ul></div>';
     
     return $output;
 } // function get_collapsed_archives

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: petroffm
 Tags: archives, collapsed, collapsing, CSS
 Requires at least: 2.8
-Tested up to: 5.0
+Tested up to: 5.1.1
 Stable tag: 1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
When there are no articles, the ending list, list-element and div tags were still being printed, causing the site layout to break.

The elements must be inside the 
```php
if ($results) {
}
```
conditional, not outside it.