### PR TITLE
Missing check for post->ID

### DIFF
--- a/collapsed-archives.php
+++ b/collapsed-archives.php
@@ -77,11 +77,11 @@ function collapsed_archives_get_collapsed_archives( $args = '' ) {
                 
                 $output .= '<li>';
                 $output .= '<input type="checkbox" id="' . $year_id . '"';
- 				if ( isset( $wp_query->post->ID ) ) {
-					if ( !$r['never_expand'] && ( ( $result->year == get_the_date('Y', $wp_query->post->ID) && !is_page() ) || ( is_page() && $result->year == date('Y') ) ) ) {
-						$output .= ' checked';
-					}
-				}
+                if ( isset( $wp_query->post->ID ) ) {
+                    if ( !$r['never_expand'] && ( ( $result->year == get_the_date('Y', $wp_query->post->ID) && !is_page() ) || ( is_page() && $result->year == date('Y') ) ) ) {
+                        $output .= ' checked';
+                    }
+                }
                 $output .= '>';
                 $output .= '<label for="' . $year_id . '"></label>';
                 

--- a/collapsed-archives.php
+++ b/collapsed-archives.php
@@ -77,9 +77,11 @@ function collapsed_archives_get_collapsed_archives( $args = '' ) {
                 
                 $output .= '<li>';
                 $output .= '<input type="checkbox" id="' . $year_id . '"';
-                if ( !$r['never_expand'] && ( ( $result->year == get_the_date('Y', $wp_query->post->ID) && !is_page() ) || ( is_page() && $result->year == date('Y') ) ) ) {
-                    $output .= ' checked';
-                }
+ 				if ( isset( $wp_query->post->ID ) ) {
+					if ( !$r['never_expand'] && ( ( $result->year == get_the_date('Y', $wp_query->post->ID) && !is_page() ) || ( is_page() && $result->year == date('Y') ) ) ) {
+						$output .= ' checked';
+					}
+				}
                 $output .= '>';
                 $output .= '<label for="' . $year_id . '"></label>';
                 


### PR DESCRIPTION
Creating a Notice in the error log:
[05-May-2019 13:15:17 UTC] PHP Notice:  Trying to get property 'ID' of non-object in /home/.../wp-content/plugins/collapsed-archives/collapsed-archives.php on line 80